### PR TITLE
fix: remove IPHONEOS_DEPLOYMENT_TARGET warnings

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -25,5 +25,10 @@ target 'ChipperFrontendExercise' do
 
   post_install do |installer|
     react_native_post_install(installer)
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings.delete 'IPHONEOS_DEPLOYMENT_TARGET'
+      end
+    end
   end
 end


### PR DESCRIPTION
### Fixed
- Fix issue about `IPHONEOS_DEPLOYMENT_TARGET` #3 

Best Regards,
Juan